### PR TITLE
Add Docker support for single-container deployment

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,5 @@
+node_modules
+**/node_modules
+backend/api/src/database/database.sqlite
+.git
+.idea

--- a/.gitignore
+++ b/.gitignore
@@ -140,3 +140,6 @@ backend/api/certificate.crt
 # idea
 
 .idea/
+
+
+data/

--- a/DOCKER.md
+++ b/DOCKER.md
@@ -1,0 +1,53 @@
+# Running HERA with Docker
+
+This project can be run as a single Docker container, bundling the API, the admin "editor" frontend, and the "viewer" frontend together.
+
+## Prerequisites
+
+- [Docker Desktop](https://www.docker.com/products/docker-desktop/) installed and running
+
+## Quick start
+
+From the repository root:
+
+```bash
+docker compose up
+```
+
+This will:
+- Build the image (multi-stage: builds both Vue/Vite frontends, then bundles them with the Express API)
+- Start the container, exposing it on port `8080`
+- Persist the SQLite database to a `./data` folder on your machine
+
+On first run, a default admin account is created:
+
+- Email: `admin@gmail.com`
+- Password: `admin`
+
+## Accessing the app
+
+- Editor (admin): `https://localhost:8080/editor`
+- Viewer: `https://localhost:8080/viewer`
+- API: `https://localhost:8080/api`
+
+The app uses a self-signed HTTPS certificate (generated automatically during the Docker build). Your browser will show a security warning on first visit — accept/continue past it to proceed.
+
+## Stopping
+
+```bash
+docker compose down
+```
+
+Your data persists in the `./data` folder between runs.
+
+## Rebuilding after code changes
+
+```bash
+docker compose up --build
+```
+
+## Notes
+
+- The database is SQLite, stored at `./data/database.sqlite` on the host.
+- Default credentials are only inserted if the database is empty (fresh
+  `./data` folder).

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,39 @@
+# ---- Stage 1: build admin frontend ----
+FROM node:20-alpine AS admin-build
+WORKDIR /app
+COPY frontend/admin/package*.json ./
+RUN npm install
+COPY frontend/admin/ ./
+RUN npm run build
+
+# ---- Stage 2: build user frontend ----
+FROM node:20-alpine AS user-build
+WORKDIR /app
+COPY frontend/user/package*.json ./
+RUN npm install
+COPY frontend/user/ ./
+RUN npm run build
+
+# ---- Stage 3: final image with API + both built frontends ----
+FROM node:20-alpine
+RUN apk add --no-cache openssl
+
+WORKDIR /app
+
+# Install API dependencies
+COPY backend/api/package*.json ./
+RUN npm install
+
+# Copy API source
+COPY backend/api/ ./
+
+# Generate self-signed certs (so fs.readFileSync doesn't crash)
+RUN openssl req -x509 -newkey rsa:2048 -keyout privatekey.key -out certificate.crt -days 365 -nodes -subj "/CN=localhost"
+
+# Copy built frontends into the API's static-serving locations
+COPY --from=admin-build /app/dist ./public/editor
+COPY --from=user-build /app/dist ./public/viewer
+
+EXPOSE 8080
+
+CMD ["node", "app.js"]

--- a/LAN-ACCESS.md
+++ b/LAN-ACCESS.md
@@ -1,0 +1,54 @@
+# Accessing HERA from Other Devices (LAN)
+
+This guide explains how to access a running HERA Docker container from another device (phone, tablet, second laptop) on the same network — useful for testing AR features, which require a phone/tablet camera.
+
+## Prerequisites
+
+- The HERA container is running (`docker compose up`) on a host machine
+- Both the host machine and the other device are connected to the **same network** (e.g. the same WiFi/hotspot)
+
+## 1. Find the host machine's local IP address
+
+On Windows, open PowerShell and run:
+
+```powershell
+ipconfig
+```
+
+Look for the **IPv4 Address** of the active network adapter (WiFi or Ethernet) you're using — e.g. `172.20.10.2`.
+
+> Note: if both machines are on a shared/managed network (e.g. university
+> or office WiFi), client isolation may prevent devices from reaching each
+> other. A personal phone hotspot is a reliable fallback for testing.
+
+## 2. Allow the port through Windows Firewall
+
+By default, Windows Firewall blocks inbound connections from other devices.
+Run this **once**, in an Administrator PowerShell:
+
+```powershell
+New-NetFirewallRule -DisplayName "HERA Docker 8080" -Direction Inbound -LocalPort 8080 -Protocol TCP -Action Allow
+```
+
+## 3. Access from the other device
+
+On the other device's browser, go to:
+
+- Viewer: `https://<HOST-IP>:8080/viewer`
+- Editor: `https://<HOST-IP>:8080/editor`
+
+Replace `<HOST-IP>` with the IP found in step 1, e.g.
+`https://172.20.10.2:8080/viewer`.
+
+## 4. Accept the self-signed certificate
+
+The app uses a self-signed HTTPS certificate. The browser will show a security warning — click through to accept/continue (e.g. "Advanced" → "Proceed"). You may need to do this **twice**: once for the page itself, and once when it tries to reach the API (a redirect/cert page will appear — accept it and you'll be redirected back).
+
+## Notes
+
+- The frontend automatically detects the hostname/IP used to access it and
+  directs API calls to the same host — no rebuild needed when your IP
+  changes (e.g. switching networks).
+- WebXR/AR sessions require either `localhost` or a secure (`https`)
+  connection — accessing via the LAN IP over `https` satisfies this
+  requirement.

--- a/backend/api/app.js
+++ b/backend/api/app.js
@@ -1,7 +1,8 @@
 import express from 'express';
-import {initializeDatabase} from "./src/orm/index.js";
-import {resetDatabase} from "./src/orm/defaults/reset.js";
-import {insertDefaults} from "./src/orm/defaults/insertDefaults.js";
+// import { initializeDatabase } from "./src/orm/index.js";
+import { initializeDatabase, ArUser } from "./src/orm/index.js";
+import { resetDatabase } from "./src/orm/defaults/reset.js";
+import { insertDefaults } from "./src/orm/defaults/insertDefaults.js";
 import project from "./src/routes/project.js";
 import auth from "./src/routes/auth.js";
 import user from "./src/routes/user.js";
@@ -24,9 +25,9 @@ export const DIRNAME = path.dirname(__filename);
 //for https only :
 import * as fs from "node:fs";
 import * as https from "node:https";
-import {Server} from "socket.io";
+import { Server } from "socket.io";
 import setupSocket from "./src/socket/index.js";
-import {errorHandler} from "./src/utils/errorHandler.js";
+import { errorHandler } from "./src/utils/errorHandler.js";
 import zip from 'express-easy-zip'
 const options = {
     key: fs.readFileSync('privatekey.key'),
@@ -40,10 +41,23 @@ app.use(cors({}))
 app.use(zip())
 app.use(errorHandler)
 
-async function main () {
-    await initializeDatabase({force: false});
-        // await resetDatabase();
-        // await insertDefaults();
+async function main() {
+    // await initializeDatabase({ force: false });
+    // // await resetDatabase();
+    // try {
+    //     await insertDefaults();
+    // } catch (e) {
+    //     console.log('Default data already exists, skipping insertDefaults()');
+    // }
+
+    await initializeDatabase({ force: false });
+    // await resetDatabase();
+    const userCount = await ArUser.count();
+    if (userCount === 0) {
+        await insertDefaults();
+    } else {
+        console.log('Database already initialized, skipping insertDefaults()');
+    }
 
     app.use(project);
     app.use(auth);
@@ -53,6 +67,19 @@ async function main () {
     app.use(asset)
     app.use(label)
     app.use('/public', express.static('public'));       //serving static files
+
+    // Serve built frontend apps (admin editor and user viewer)
+    app.use('/editor', express.static('public/editor'));
+    app.use('/viewer', express.static('public/viewer'));
+
+    app.get('/editor/*', (req, res) => {
+        res.sendFile(path.join(DIRNAME, 'public/editor/index.html'));
+    });
+
+    app.get('/viewer/*', (req, res) => {
+        res.sendFile(path.join(DIRNAME, 'public/viewer/index.html'));
+    });
+
 
     const httpsServer = https.createServer(options, app)
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,8 @@
+services:
+  hera:
+    build: .
+    ports:
+      - "8080:8080"
+    volumes:
+      - ./data:/app/src/database
+    restart: unless-stopped

--- a/frontend/admin/src/js/endpoints.js
+++ b/frontend/admin/src/js/endpoints.js
@@ -1,6 +1,10 @@
-// const HOST = 'https://192.168.83.116';
-const HOST = 'https://localhost';
-// const HOST = 'https://172.22.69.22';
+// // const HOST = 'https://192.168.83.116';
+// const HOST = 'https://localhost';
+// // const HOST = 'https://172.22.69.22';
+
+// export const ENDPOINT = `${HOST}:8080/api/`;
+
+const HOST = `${window.location.protocol}//${window.location.hostname}`;
 
 export const ENDPOINT = `${HOST}:8080/api/`;
 

--- a/frontend/user/src/js/endpoints.js
+++ b/frontend/user/src/js/endpoints.js
@@ -1,10 +1,14 @@
-// const HOST = 'https://192.168.65.116';
-const HOST = 'https://localhost';
-// const HOST = 'https://192.168.1.10';
+// // const HOST = 'https://192.168.65.116';
+// const HOST = 'https://localhost';
+// // const HOST = 'https://192.168.1.10';
+
+// export const ENDPOINT = `${HOST}:8080/api/`;
+
+const HOST = `${window.location.protocol}//${window.location.hostname}`;
 
 export const ENDPOINT = `${HOST}:8080/api/`;
 
-export const HEADERS= {
+export const HEADERS = {
     'Content-Type': "application/json"
 };
 


### PR DESCRIPTION
## Description

This PR adds Docker support, packaging the API, admin editor, and viewer into a single container for easy local setup and deployment.

## What's included

- `Dockerfile` — multi-stage build: builds both Vue/Vite frontends (`admin` → `/editor`, `user` → `/viewer`), then bundles them with the Express API into one lightweight image
- `docker-compose.yml` — single command (`docker compose up`) to build and run everything
- `.dockerignore` — excludes `node_modules`, `.git`, and the local SQLite database from the build context
- `DOCKER.md` — quick-start guide for running the app via Docker
- `LAN-ACCESS.md` — guide for accessing the running container from other devices on the same network (useful for testing AR on phones/tablets)

## Backend changes (`backend/api/app.js`)

- `insertDefaults()` is now only called if the `ArUsers` table is empty, preventing a crash on container restart when default data already exists

## Frontend changes (`endpoints.js` in both `admin` and `user`)

- The API host is now derived dynamically from `window.location` instead of being hardcoded to `https://localhost`. This means the same build works whether accessed via `localhost`, a LAN IP, or a future domain — no rebuild needed when the access point changes.

## How to test

```bash
docker compose up
```

Then visit `https://localhost:8080/editor` (default login: `admin@gmail.com` / `admin`) and `https://localhost:8080/viewer`. Data persists across restarts via a `./data` volume.

## Notes

- The container generates a self-signed TLS certificate at build time (required by the existing app code, which expects `privatekey.key`/`certificate.crt`)
- This is intended as a foundation — production deployments behind a real domain/reverse proxy with proper TLS are a separate, future consideration